### PR TITLE
fix gnome-flashback on Ubuntu 15.10+

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+x2goserver (4.1.0.0-0~1309~ubuntu16.04.1.03~eugenesan~xenial1) xenial; urgency=medium
+
+  * debian/changelog: update with Ubuntu 15.10+ fixes
+  * debian/control: add libgles{1,2}-mesa to x2goserver's recommends to fix clutter/GL related apps
+  * x2goruncommand: add support for unity on ubuntu 15.10+ (might work in future)
+  * x2goruncommand: add support for gnome-flashback on ubuntu 15.10+
+  * x2goruncommand: set normal PATH
+  * x2goruncommand: fix initial monitor configuration
+  * x2goruncommand: fix formatting
+
+ -- Eugene San (eugenesan) <eugenesan@gmail.com>  Sun, 21 Feb 2016 13:47:53 -0500
+
+x2goserver (4.1.0.0-0~1309~ubuntu16.04.1) xenial; urgency=low
+
+  * Auto build.
+
+ -- X2Go <x2go-dev@x2go.org>  Sun, 21 Feb 2016 02:03:22 +0000
+
 x2goserver (4.1.0.0-0x2go1.1) UNRELEASED; urgency=low
 
   [ Mike Gabriel ]

--- a/debian/control
+++ b/debian/control
@@ -51,6 +51,8 @@ Recommends:
  x2goserver-xsession (>= ${source:Version}), x2goserver-xsession (<< ${source:Version}.1~),
  x2goserver-fmbindings (>= ${source:Version}), x2goserver-fmbindings (<< ${source:Version}.1~),
  x2goserver-printing (>= ${source:Version}), x2goserver-printing (<< ${source:Version}.1~),
+ libgles1-mesa,
+ libgles2-mesa
 Suggests:
  rdesktop,
  pulseaudio-utils

--- a/debian/x2goserver.install
+++ b/debian/x2goserver.install
@@ -3,6 +3,7 @@ x2goserver/sbin/x2go*                   /usr/sbin/
 x2goserver/lib/x2go*                    /usr/lib/x2go/
 x2goserver/etc/x2go_logout*             /etc/x2go/
 x2goserver/etc/x2goagent.options        /etc/x2go/
+x2goserver/etc/monitors.xml             /etc/x2go/
 x2goserver/etc/sudoers.d/x2goserver     /etc/sudoers.d/
 x2goserver/etc/logcheck/ignore.d.server/x2goserver /etc/logcheck/ignore.d.server/
 x2goserver/VERSION.x2goserver           /usr/share/x2go/versions/

--- a/x2goserver/bin/x2goruncommand
+++ b/x2goserver/bin/x2goruncommand
@@ -177,7 +177,14 @@ if [ "$cmd" == "GNOME" ] || [ "$cmd" == "gnome-session" ]; then
 
 elif ([ "$cmd" == "UNITY" ] || [ "$cmd" == "unity" ]); then
 	cmd="/usr/bin/gnome-session"
-	if [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$(echo "$DISTRIB_RELEASE >= 12.10" | bc)" == "1" ]; then
+	if [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$(echo "$DISTRIB_RELEASE >= 15.10" | bc)" == "1" ]; then
+		export DESKTOP_SESSION="ubuntu"
+		export XDG_CURRENT_DESKTOP="Unity"
+		export BASESESSION="gnome-session"
+		export XSESSION_PARAM="gnome-session --session=ubuntu"
+
+		args=" --session=$DESKTOP_SESSION --disable-acceleration-check"
+	elif [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$(echo "$DISTRIB_RELEASE >= 12.10" | bc)" == "1" ]; then
 		export DESKTOP_SESSION="ubuntu"
 		args=" --session=$DESKTOP_SESSION"
 	elif [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$(echo "$DISTRIB_RELEASE == 11.10" | bc)" == "1" -o "$(echo "$DISTRIB_RELEASE == 12.04" | bc)" == "1" ]; then

--- a/x2goserver/bin/x2goruncommand
+++ b/x2goserver/bin/x2goruncommand
@@ -120,6 +120,11 @@ fi
 #	Additionally, $GTK_MODULES must include "unity-gtk-module"
 #	$GTK_MODULES does not need that value for any other distro
 #	or any earlier release of Ubuntu.
+# Ubuntu 15.10 (utopic) and later:
+#	GNOME -> gnome-session --session=gnome-flashback-metacity --disable-acceleration-check
+#	UNITY -> gnome-session --session=ubuntu
+#	(GNOME3 based desktop shells)
+#	Since 15.10 no need to deal with $GTK_MODULES as it is set automatically by Xsession
 #
 #	The logic for launching GNOME should be generic enough
 #	to work with every other distro.
@@ -141,7 +146,13 @@ export PATH
 
 if [ "$cmd" == "GNOME" ] || [ "$cmd" == "gnome-session" ]; then
 	cmd="/usr/bin/gnome-session"
-	if [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$(echo "$DISTRIB_RELEASE >= 13.10" | bc)" == "1" ]; then
+	if [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$(echo "$DISTRIB_RELEASE >= 15.10" | bc)" == "1" ]; then
+		export DESKTOP_SESSION="gnome-flashback-metacity"
+		export XDG_CURRENT_DESKTOP="GNOME-Flashback:Unity"
+		export BASESESSION="gnome-flashback-metacity"
+		export XSESSION_PARAM="/usr/lib/gnome-flashback/gnome-flashback-metacity"
+		args=" --session=$DESKTOP_SESSION --disable-acceleration-check"
+	elif [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$(echo "$DISTRIB_RELEASE >= 13.10" | bc)" == "1" ]; then
 		export DESKTOP_SESSION="gnome-flashback"
 		if [ -z "$GTK_MODULES" ] ; then
 			export GTK_MODULES="unity-gtk-module"
@@ -325,7 +336,7 @@ if [ "$EXEC" != "" ] && [ -x "$EXEC" ]; then
 	if x2gofeature X2GO_XSESSION &>/dev/null && [ "x$X2GO_SESS_TYPE" = "xD" ]; then
 		STARTUP="$cmd$args"
 		"$X2GO_LIB_PATH/x2gosyslog" "$0" "notice" "launching session with Xsession-x2go mechanism, using STARTUP=\"$STARTUP\""
-		XSESSION_EXEC="$cmd" STARTUP="/usr/bin/env LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ${STARTUP}" /etc/x2go/Xsession
+		XSESSION_EXEC="$cmd" STARTUP="/usr/bin/env LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ${STARTUP}" /etc/x2go/Xsession "${XSESSION_PARAM}"
 	else
 		"$X2GO_LIB_PATH/x2gosyslog" "$0" "debug" "executing command \"$cmd$args\"..."
 

--- a/x2goserver/bin/x2goruncommand
+++ b/x2goserver/bin/x2goruncommand
@@ -133,6 +133,12 @@ if [ ! -f ~/.config/monitors.xml ]; then
 	cp /etc/x2go/monitors.xml ~/.config/
 fi
 
+# Set path as for interactive sessions
+# upstart daemon can't be found found without it
+# and who knows what else might be broken otherwise
+eval `cat /etc/environment`
+export PATH
+
 if [ "$cmd" == "GNOME" ] || [ "$cmd" == "gnome-session" ]; then
 	cmd="/usr/bin/gnome-session"
 	if [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$(echo "$DISTRIB_RELEASE >= 13.10" | bc)" == "1" ]; then

--- a/x2goserver/bin/x2goruncommand
+++ b/x2goserver/bin/x2goruncommand
@@ -127,6 +127,12 @@ fi
 #	Also, it appears that some Linux GNOME2 distros need DESKTOP_SESSION="gnome"
 #	while others do not.
 
+# Workaround initial display configuration
+if [ ! -f ~/.config/monitors.xml ]; then
+	mkdir -p ~/.config
+	cp /etc/x2go/monitors.xml ~/.config/
+fi
+
 if [ "$cmd" == "GNOME" ] || [ "$cmd" == "gnome-session" ]; then
 	cmd="/usr/bin/gnome-session"
 	if [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$(echo "$DISTRIB_RELEASE >= 13.10" | bc)" == "1" ]; then

--- a/x2goserver/bin/x2goruncommand
+++ b/x2goserver/bin/x2goruncommand
@@ -99,33 +99,33 @@ fi
 # To make the GNOME variants start up properly on Ubuntu, we have to make the following differentiations
 
 # Ubuntu 10.10 and earlier (maverick):
-#		 GNOME -> gnome-session
-#		 (would start GNOME2)
+#	GNOME -> gnome-session
+#	(would start GNOME2)
 # Ubuntu 11.04 (natty):
-#		 GNOME -> gnome-session --session=2d-gnome
-#		 UNITY -> gnome-session --session=2d-ubuntu
-#		 (GNOME3 based desktop shells)
+#	GNOME -> gnome-session --session=2d-gnome
+#	UNITY -> gnome-session --session=2d-ubuntu
+#	(GNOME3 based desktop shells)
 # Ubuntu 11.10 (oneiric) & 12.04 (precise):
-#		 GNOME -> gnome-session --session=gnome-fallback
-#		 UNITY -> gnome-session --session=ubuntu-2d
-#		 (GNOME3 based desktop shells)
+#	GNOME -> gnome-session --session=gnome-fallback
+#	UNITY -> gnome-session --session=ubuntu-2d
+#	(GNOME3 based desktop shells)
 # Ubuntu 12.10 (quantal):
-#		 GNOME -> gnome-session --session=gnome-fallback
-#		 UNITY -> gnome-session --session=ubuntu
-#		 (GNOME3 based desktop shells)
+#	GNOME -> gnome-session --session=gnome-fallback
+#	UNITY -> gnome-session --session=ubuntu
+#	(GNOME3 based desktop shells)
 # Ubuntu 13.10 (raring) and later:
-#		 GNOME -> gnome-session --session=gnome-flashback
-#		 UNITY -> gnome-session --session=ubuntu
-#		 (GNOME3 based desktop shells)
-#		 Additionally, $GTK_MODULES must include "unity-gtk-module".
-#		 $GTK_MODULES does not need tha value for any other distro
-#                or any earlier release of Ubuntu.
+#	GNOME -> gnome-session --session=gnome-flashback
+#	UNITY -> gnome-session --session=ubuntu
+#	(GNOME3 based desktop shells)
+#	Additionally, $GTK_MODULES must include "unity-gtk-module"
+#	$GTK_MODULES does not need that value for any other distro
+#	or any earlier release of Ubuntu.
 #
-#		 The logic for launching GNOME should be generic enough
-#                to work with every other distro.
+#	The logic for launching GNOME should be generic enough
+#	to work with every other distro.
 #
-#		 Also, it appears that some Linux GNOME2 distros need DESKTOP_SESSION="gnome"
-#                while others do not.
+#	Also, it appears that some Linux GNOME2 distros need DESKTOP_SESSION="gnome"
+#	while others do not.
 
 if [ "$cmd" == "GNOME" ] || [ "$cmd" == "gnome-session" ]; then
 	cmd="/usr/bin/gnome-session"
@@ -137,20 +137,20 @@ if [ "$cmd" == "GNOME" ] || [ "$cmd" == "gnome-session" ]; then
 			export GTK_MODULES="$GTK_MODULES:unity-gtk-module"
 		fi
 		args=" --session=$DESKTOP_SESSION"
-        elif [ -e /usr/share/gnome-session/sessions/gnome-flashback.session ]; then
-                export DESKTOP_SESSION="gnome-flashback"
-                args=" --session=$DESKTOP_SESSION"
-        elif [ -e /usr/share/gnome-session/sessions/gnome-fallback.session ]; then
-                export DESKTOP_SESSION="gnome-fallback"
-                args=" --session=$DESKTOP_SESSION"
-        elif [ -e /usr/share/gnome-session/sessions/2d-gnome.session ]; then
-                export DESKTOP_SESSION="2d-gnome"
-                args=" --session=$DESKTOP_SESSION"
-        elif [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$(echo "$DISTRIB_RELEASE <= 10.10" | bc)" == "1" ]; then
-                export DESKTOP_SESSION="gnome"
+	elif [ -e /usr/share/gnome-session/sessions/gnome-flashback.session ]; then
+		export DESKTOP_SESSION="gnome-flashback"
+		args="--session=$DESKTOP_SESSION"
+	elif [ -e /usr/share/gnome-session/sessions/gnome-fallback.session ]; then
+		export DESKTOP_SESSION="gnome-fallback"
+		args=" --session=$DESKTOP_SESSION"
+	elif [ -e /usr/share/gnome-session/sessions/2d-gnome.session ]; then
+		export DESKTOP_SESSION="2d-gnome"
+		args=" --session=$DESKTOP_SESSION"
+	elif [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$(echo "$DISTRIB_RELEASE <= 10.10" | bc)" == "1" ]; then
+		export DESKTOP_SESSION="gnome"
 	elif cat /etc/debian_version | egrep "^(squeeze|6\.).*" >/dev/null; then
-                export DESKTOP_SESSION="gnome"
-        fi
+		export DESKTOP_SESSION="gnome"
+	fi
 
 elif ([ "$cmd" == "UNITY" ] || [ "$cmd" == "unity" ]); then
 	cmd="/usr/bin/gnome-session"

--- a/x2goserver/etc/monitors.xml
+++ b/x2goserver/etc/monitors.xml
@@ -1,0 +1,19 @@
+<monitors version="1">
+  <configuration>
+      <clone>no</clone>
+      <output name="default">
+          <vendor>???</vendor>
+          <product>0x0000</product>
+          <serial>0x00000000</serial>
+          <width>1024</width>
+          <height>768</height>
+          <rate>60</rate>
+          <x>0</x>
+          <y>0</y>
+          <rotation>normal</rotation>
+          <reflect_x>no</reflect_x>
+          <reflect_y>no</reflect_y>
+          <primary>yes</primary>
+      </output>
+  </configuration>
+</monitors>


### PR DESCRIPTION
I've managed to fix gnome-flashback on Ubuntu 15.10+ (actually tested only
on 16.04).

Summary:
1. environment set by x2goruncommnd was insufficient for gnome-flashback and upstart to work. Following variables had to be added: XDG_CURRENT_DESKTOP and BASESESSION
2. In normal sessions Xsession is executed with parameter, new variable XSESSION_PARAM was introduced and passed to Xsession
3. Variable DESKTOP_SESSION had to be updated to gnome-flashback-metacity
4. gnome-session now requires --disable-acceleration-check parameter
5. PATH had to be synced with /etc/environment for upstart to work
6. Initial display configuration was fixed by installing sane default in ~/.config/monitors.xml on first run
7. On the way, formatting of x2gorunner was fixed
8. New dependencies (libgles{1,2}-mesa) had to be introduced to libnx-x11-6.
    control-center and probably other applications based clutter/GL, won't work otherwise.

Big thanks to _Alberts Muktupāvels_ and _Alkis Georgopoulos_ (https://mail.gnome.org/archives/gnome-flashback-list/2015-December/msg00014.html)

Regards
